### PR TITLE
Enable GitHub Action token validator

### DIFF
--- a/pkg/controller/cli/serve.go
+++ b/pkg/controller/cli/serve.go
@@ -21,8 +21,9 @@ func cmdServe() *cli.Command {
 		slackToken  string
 		policyFiles cli.StringSlice
 
-		githubSecrets       cli.StringSlice
-		enableGoogleIDToken bool
+		githubSecrets           cli.StringSlice
+		enableGitHubActionToken bool
+		enableGoogleIDToken     bool
 	)
 
 	return &cli.Command{
@@ -60,7 +61,12 @@ func cmdServe() *cli.Command {
 				EnvVars:     []string{"NOUNIFY_GITHUB_SECRET"},
 				Destination: &githubSecrets,
 			},
-
+			&cli.BoolFlag{
+				Name:        "github-action-token",
+				Usage:       "Enable GitHub action token verification",
+				EnvVars:     []string{"NOUNIFY_GITHUB_ACTION_TOKEN"},
+				Destination: &enableGitHubActionToken,
+			},
 			&cli.BoolFlag{
 				Name:        "google-id-token",
 				Usage:       "Enable Google ID token verification",

--- a/pkg/controller/server/server.go
+++ b/pkg/controller/server/server.go
@@ -12,9 +12,10 @@ import (
 )
 
 type config struct {
-	policy                interfaces.Policy
-	githubSecrets         []string
-	validateGoogleIDToken bool
+	policy                    interfaces.Policy
+	githubSecrets             []string
+	validateGitHubActionToken bool
+	validateGoogleIDToken     bool
 }
 
 type Option func(*config)
@@ -28,6 +29,12 @@ func WithPolicy(policy interfaces.Policy) Option {
 func WithGitHubSecret(secret string) Option {
 	return func(cfg *config) {
 		cfg.githubSecrets = append(cfg.githubSecrets, secret)
+	}
+}
+
+func WithGitHubActionTokenValidation() Option {
+	return func(cfg *config) {
+		cfg.validateGitHubActionToken = true
 	}
 }
 
@@ -52,6 +59,9 @@ func New(uc interfaces.UseCases, options ...Option) http.Handler {
 		r.Use(logger)
 		for _, secret := range cfg.githubSecrets {
 			r.Use(authGitHubWebhook(secret))
+		}
+		if cfg.validateGitHubActionToken {
+			r.Use(authGitHubActionToken())
 		}
 		if cfg.validateGoogleIDToken {
 			r.Use(authGoogleIDToken())

--- a/pkg/controller/server/testdata/policy_github_action.rego
+++ b/pkg/controller/server/testdata/policy_github_action.rego
@@ -1,0 +1,5 @@
+package auth
+
+allow {
+    input.auth.github.action.actor == "m-mizutani"
+}

--- a/pkg/controller/server/testdata/policy_github_auth.rego
+++ b/pkg/controller/server/testdata/policy_github_auth.rego
@@ -1,5 +1,5 @@
 package auth
 
 allow {
-    input.auth.github != null
+    input.auth.github.app != null
 }

--- a/pkg/domain/model/auth.go
+++ b/pkg/domain/model/auth.go
@@ -5,7 +5,12 @@ import (
 	"strconv"
 )
 
-type GitHubWebhookAuth struct {
+type GitHubAuth struct {
+	App    *GitHubAppAuth    `json:"app"`
+	Action GitHubActionToken `json:"action"`
+}
+
+type GitHubAppAuth struct {
 	// Example
 	/*
 		X-GitHub-Delivery: 2b844992-3689-11ef-89d9-8126a7fa0a02
@@ -22,8 +27,8 @@ type GitHubWebhookAuth struct {
 	InstallType string `json:"install_type"`
 }
 
-func NewGitHubWebhookAuth(r *http.Request) *GitHubWebhookAuth {
-	auth := GitHubWebhookAuth{
+func NewGitHubAppAuth(r *http.Request) *GitHubAppAuth {
+	auth := GitHubAppAuth{
 		Delivery:    r.Header.Get("X-GitHub-Delivery"),
 		Event:       r.Header.Get("X-GitHub-Event"),
 		InstallType: r.Header.Get("X-GitHub-Hook-Installation-Target-Type"),
@@ -39,3 +44,5 @@ func NewGitHubWebhookAuth(r *http.Request) *GitHubWebhookAuth {
 
 	return &auth
 }
+
+type GitHubActionToken map[string]any

--- a/pkg/domain/model/query.go
+++ b/pkg/domain/model/query.go
@@ -75,8 +75,8 @@ type AuthQueryInput struct {
 	Path   string            `json:"path"`
 	Header map[string]string `json:"header"`
 	Auth   struct {
-		GitHub *GitHubWebhookAuth `json:"github"`
-		Google map[string]any     `json:"google"`
+		GitHub GitHubAuth     `json:"github"`
+		Google map[string]any `json:"google"`
 	} `json:"auth"`
 }
 

--- a/pkg/utils/ctxutil/auth.go
+++ b/pkg/utils/ctxutil/auth.go
@@ -9,16 +9,29 @@ import (
 type ctxAuthKey string
 
 const (
-	ctxAuthGitHubWebhook = ctxAuthKey("github_webhook_auth")
+	ctxAuthGitHubApp     = ctxAuthKey("github_app_auth")
+	ctxAuthGitHubAction  = ctxAuthKey("github_action_auth")
 	ctxAuthGoogleIDToken = ctxAuthKey("google_id_token")
 )
 
-func WithGitHubWebhookAuth(ctx context.Context, auth *model.GitHubWebhookAuth) context.Context {
-	return context.WithValue(ctx, ctxAuthGitHubWebhook, auth)
+func WithGitHubAppAuth(ctx context.Context, auth *model.GitHubAppAuth) context.Context {
+	return context.WithValue(ctx, ctxAuthGitHubApp, auth)
 }
 
-func GitHubWebhookAuth(ctx context.Context) *model.GitHubWebhookAuth {
-	auth, ok := ctx.Value(ctxAuthGitHubWebhook).(*model.GitHubWebhookAuth)
+func GitHubAppAuth(ctx context.Context) *model.GitHubAppAuth {
+	auth, ok := ctx.Value(ctxAuthGitHubApp).(*model.GitHubAppAuth)
+	if !ok {
+		return nil
+	}
+	return auth
+}
+
+func WithGitHubActionToken(ctx context.Context, auth model.GitHubActionToken) context.Context {
+	return context.WithValue(ctx, ctxAuthGitHubAction, auth)
+}
+
+func GitHubActionToken(ctx context.Context) model.GitHubActionToken {
+	auth, ok := ctx.Value(ctxAuthGitHubAction).(model.GitHubActionToken)
 	if !ok {
 		return nil
 	}


### PR DESCRIPTION
Allow invoke nounify with GitHub Action token like following GitHub Action

```yml
jobs:
  test_github_oidc:
    runs-on: ubuntu-latest
    permissions:
      id-token: write
    steps:
      - run: |
          IDTOKEN=$(curl -H "Authorization: bearer  ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" ${ACTIONS_ID_TOKEN_REQUEST_URL} -H "Accept: application/json; api-version=2.0" -H "Content-Type: application/json" -d "{}" | jq -r '.value')
          curl -v -H "Authorization: bearer ${IDTOKEN}" https://emhkq5vqrco2fpr6zqlctbjale0eyygt.lambda-url.ap-northeast-1.on.aws/
```