### PR TITLE
add(server): Change status code to return OK when auth error

### DIFF
--- a/pkg/controller/cli/serve.go
+++ b/pkg/controller/cli/serve.go
@@ -24,6 +24,7 @@ func cmdServe() *cli.Command {
 		githubSecrets           cli.StringSlice
 		enableGitHubActionToken bool
 		enableGoogleIDToken     bool
+		enableAuthErrOK         bool
 	)
 
 	return &cli.Command{
@@ -72,6 +73,12 @@ func cmdServe() *cli.Command {
 				Usage:       "Enable Google ID token verification",
 				EnvVars:     []string{"NOUNIFY_GOOGLE_ID_TOKEN"},
 				Destination: &enableGoogleIDToken,
+			},
+			&cli.BoolFlag{
+				Name:        "auth-err-ok",
+				Usage:       "Return 200 OK when authentication error",
+				EnvVars:     []string{"NOUNIFY_AUTH_ERR_OK"},
+				Destination: &enableAuthErrOK,
 			},
 		},
 

--- a/pkg/controller/server/auth.go
+++ b/pkg/controller/server/auth.go
@@ -175,7 +175,7 @@ func authFromContext(ctx context.Context) model.AuthContext {
 	return auth
 }
 
-func authWithPolicy(policy interfaces.Policy) middlewareFunc {
+func authWithPolicy(policy interfaces.Policy, errCode int) middlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			input := model.AuthQueryInput{
@@ -199,7 +199,9 @@ func authWithPolicy(policy interfaces.Policy) middlewareFunc {
 			ctxutil.Logger(r.Context()).Debug("auth query result", "input", input, "output", output)
 
 			if !output.Allow {
-				handleError(ctx, w, types.ErrForbidden)
+				handleError(ctx, w, types.ErrForbidden,
+					handleErrorWithForceCode(errCode),
+				)
 				return
 			}
 


### PR DESCRIPTION
The option changes return code to HTTP OK (200) when auth error. It's for stopping retry loop of notification (e.g. Google Cloud Pub/Sub)