### PR TITLE
Rename Amazon SNS with AWS SNS

### DIFF
--- a/pkg/controller/cli/serve.go
+++ b/pkg/controller/cli/serve.go
@@ -33,7 +33,7 @@ func cmdServe() *cli.Command {
 		githubSecrets           cli.StringSlice
 		enableGitHubActionToken bool
 		enableGoogleIDToken     bool
-		enableAmazonSNS         bool
+		enableAwsSNS            bool
 		enableAuthErrOK         bool
 
 		sentry config.Sentry
@@ -83,10 +83,10 @@ func cmdServe() *cli.Command {
 			Destination: &enableGoogleIDToken,
 		},
 		&cli.BoolFlag{
-			Name:        "amazon-sns",
+			Name:        "aws-sns",
 			Usage:       "Enable Amazon SNS message verification",
-			EnvVars:     []string{"NOUNIFY_AMAZON_SNS"},
-			Destination: &enableAmazonSNS,
+			EnvVars:     []string{"NOUNIFY_AWS_SNS"},
+			Destination: &enableAwsSNS,
 		},
 		&cli.BoolFlag{
 			Name:        "auth-err-ok",
@@ -131,8 +131,8 @@ func cmdServe() *cli.Command {
 			if enableGitHubActionToken {
 				serverOptions = append(serverOptions, server.WithGitHubActionTokenValidation())
 			}
-			if enableAmazonSNS {
-				serverOptions = append(serverOptions, server.WithAmazonSNSValidation())
+			if enableAwsSNS {
+				serverOptions = append(serverOptions, server.WithAwsSNSValidation())
 			}
 
 			if enableAuthErrOK {

--- a/pkg/controller/server/auth.go
+++ b/pkg/controller/server/auth.go
@@ -162,7 +162,7 @@ type snsMessage struct {
 	UnsubscribeURL   string `json:"UnsubscribeURL"`
 }
 
-func authAmazonSNS() middlewareFunc {
+func authAwsSNS() middlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			auth, err := validateSNSMessage(r)
@@ -171,7 +171,7 @@ func authAmazonSNS() middlewareFunc {
 				return
 			}
 			if auth != nil {
-				r = r.WithContext(ctxutil.WithAmazonSNSAuth(r.Context(), auth))
+				r = r.WithContext(ctxutil.WithAwsSNSAuth(r.Context(), auth))
 			}
 
 			next.ServeHTTP(w, r)
@@ -179,7 +179,7 @@ func authAmazonSNS() middlewareFunc {
 	}
 }
 
-func validateSNSMessage(r *http.Request) (*model.AmazonSNSAuth, error) {
+func validateSNSMessage(r *http.Request) (*model.AwsSNSAuth, error) {
 	if r.Header.Get("X-Amz-Sns-Message-Id") == "" {
 		return nil, nil
 	}
@@ -213,7 +213,7 @@ func validateSNSMessage(r *http.Request) (*model.AmazonSNSAuth, error) {
 		return nil, goerr.Wrap(err, "failed to verify signature")
 	}
 
-	return &model.AmazonSNSAuth{
+	return &model.AwsSNSAuth{
 		Type:      msg.Type,
 		MessageId: msg.MessageId,
 		TopicArn:  msg.TopicArn,
@@ -351,7 +351,7 @@ func authFromContext(ctx context.Context) model.AuthContext {
 		}
 	}
 
-	if snsAuth := ctxutil.AmazonSNSAuth(ctx); snsAuth != nil {
+	if snsAuth := ctxutil.AwsSNSAuth(ctx); snsAuth != nil {
 		auth.AWS.SNS = snsAuth
 	}
 

--- a/pkg/controller/server/auth_test.go
+++ b/pkg/controller/server/auth_test.go
@@ -176,16 +176,16 @@ func TestGoogleIDTokenAuth(t *testing.T) {
 }
 
 //go:embed testdata/amazon_sns_message.json
-var amazonSNSMessage []byte
+var awsSNSMessage []byte
 
 func TestValidateSNSMessage(t *testing.T) {
 	_ = testutil.LoadEnv(t, "TEST_AMAZON_SNS_MESSAGE_VALIDATION")
 
-	r := httptest.NewRequest("POST", "/msg/sns", bytes.NewReader(amazonSNSMessage))
+	r := httptest.NewRequest("POST", "/msg/sns", bytes.NewReader(awsSNSMessage))
 	r.Header.Set("X-Amz-Sns-Message-Id", "xxx")
 	auth, err := server.ValidateSNSMessage(r)
 	gt.NoError(t, err)
-	gt.Equal(t, auth, &model.AmazonSNSAuth{
+	gt.Equal(t, auth, &model.AwsSNSAuth{
 		Type:      "Notification",
 		MessageId: "64663998-0a7d-5f91-b7e6-669c0dcbf767",
 		TopicArn:  "arn:aws:sns:ap-northeast-1:783957204773:nounify-test",
@@ -194,16 +194,16 @@ func TestValidateSNSMessage(t *testing.T) {
 }
 
 //go:embed testdata/amazon_sns_subscribe.json
-var amazonSNSSubscribe []byte
+var awsSNSSubscribe []byte
 
 func TestValidateSNSSubscribe(t *testing.T) {
 	_ = testutil.LoadEnv(t, "TEST_AMAZON_SNS_MESSAGE_VALIDATION")
 
-	r := httptest.NewRequest("POST", "/msg/sns", bytes.NewReader(amazonSNSSubscribe))
+	r := httptest.NewRequest("POST", "/msg/sns", bytes.NewReader(awsSNSSubscribe))
 	r.Header.Set("X-Amz-Sns-Message-Id", "xxx")
 	auth, err := server.ValidateSNSMessage(r)
 	gt.NoError(t, err)
-	gt.Equal(t, auth, &model.AmazonSNSAuth{
+	gt.Equal(t, auth, &model.AwsSNSAuth{
 		Type:      "SubscriptionConfirmation",
 		MessageId: "1e25b020-e5de-4e10-851e-d214fdfca781",
 		TopicArn:  "arn:aws:sns:ap-northeast-1:783957204773:nounify-test",

--- a/pkg/controller/server/server.go
+++ b/pkg/controller/server/server.go
@@ -22,7 +22,7 @@ type config struct {
 	githubSecrets             []string
 	validateGitHubActionToken bool
 	validateGoogleIDToken     bool
-	validateAmazonSNS         bool
+	validateAwsSNS            bool
 	authErrStatusCode         int
 }
 
@@ -52,9 +52,9 @@ func WithGoogleIDTokenValidation() Option {
 	}
 }
 
-func WithAmazonSNSValidation() Option {
+func WithAwsSNSValidation() Option {
 	return func(cfg *config) {
-		cfg.validateAmazonSNS = true
+		cfg.validateAwsSNS = true
 	}
 }
 
@@ -88,8 +88,8 @@ func New(uc interfaces.UseCases, options ...Option) http.Handler {
 		if cfg.validateGoogleIDToken {
 			r.Use(authGoogleIDToken())
 		}
-		if cfg.validateAmazonSNS {
-			r.Use(authAmazonSNS())
+		if cfg.validateAwsSNS {
+			r.Use(authAwsSNS())
 		}
 
 		if cfg.policy != nil {

--- a/pkg/controller/server/server_test.go
+++ b/pkg/controller/server/server_test.go
@@ -117,7 +117,7 @@ func TestParseRequest(t *testing.T) {
 
 	t.Run("amazon SNS", test(testCase{
 		req: func() *http.Request {
-			r := httptest.NewRequest(http.MethodPost, "/msg/schema", bytes.NewReader(amazonSNSMessage))
+			r := httptest.NewRequest(http.MethodPost, "/msg/schema", bytes.NewReader(awsSNSMessage))
 			r.Header.Set("X-Amz-Sns-Message-Id", "message-id")
 			r.Header.Set("Content-Type", "text/plain; charset=UTF-8")
 			return r

--- a/pkg/domain/model/auth.go
+++ b/pkg/domain/model/auth.go
@@ -48,10 +48,10 @@ func NewGitHubAppAuth(r *http.Request) *GitHubAppAuth {
 type GitHubActionToken map[string]any
 
 type AwsAuth struct {
-	SNS *AmazonSNSAuth `json:"sns"`
+	SNS *AwsSNSAuth `json:"sns"`
 }
 
-type AmazonSNSAuth struct {
+type AwsSNSAuth struct {
 	Type      string `json:"Type"`
 	MessageId string `json:"MessageId"`
 	TopicArn  string `json:"TopicArn"`

--- a/pkg/utils/ctxutil/auth.go
+++ b/pkg/utils/ctxutil/auth.go
@@ -12,7 +12,7 @@ const (
 	ctxAuthGitHubApp     = ctxAuthKey("github_app_auth")
 	ctxAuthGitHubAction  = ctxAuthKey("github_action_auth")
 	ctxAuthGoogleIDToken = ctxAuthKey("google_id_token")
-	ctxAuthAmazonSNS     = ctxAuthKey("amazon_sns_auth")
+	ctxAuthAwsSNS        = ctxAuthKey("amazon_sns_auth")
 )
 
 func WithGitHubAppAuth(ctx context.Context, auth *model.GitHubAppAuth) context.Context {
@@ -51,12 +51,12 @@ func GoogleIDToken(ctx context.Context) map[string]any {
 	return token
 }
 
-func WithAmazonSNSAuth(ctx context.Context, auth *model.AmazonSNSAuth) context.Context {
-	return context.WithValue(ctx, ctxAuthAmazonSNS, auth)
+func WithAwsSNSAuth(ctx context.Context, auth *model.AwsSNSAuth) context.Context {
+	return context.WithValue(ctx, ctxAuthAwsSNS, auth)
 }
 
-func AmazonSNSAuth(ctx context.Context) *model.AmazonSNSAuth {
-	auth, ok := ctx.Value(ctxAuthAmazonSNS).(*model.AmazonSNSAuth)
+func AwsSNSAuth(ctx context.Context) *model.AwsSNSAuth {
+	auth, ok := ctx.Value(ctxAuthAwsSNS).(*model.AwsSNSAuth)
 	if !ok {
 		return nil
 	}


### PR DESCRIPTION
Technically, it is Amazon SNS is official name, but for the sake of clarity, let me rename it AWS SNS.